### PR TITLE
Make the compilation status clear.

### DIFF
--- a/buildAndTest.sh
+++ b/buildAndTest.sh
@@ -15,7 +15,7 @@ tests="Criteo.Profiling.Tracing.UTest"
 
 check_availability "dotnet"
 
-dotnet restore
-dotnet build $src
-dotnet build $tests
-dotnet test $tests
+dotnet restore         \
+&& dotnet build $src   \
+&& dotnet build $tests \
+&& dotnet test $tests  \


### PR DESCRIPTION
The compilation could pass with errors.
It's not the case anymore