### PR TITLE
Enable middleware to extract trace from incoming request headers.

### DIFF
--- a/zipkin4net-aspnetcore/Criteo.Profiling.Tracing.Middleware/TracingMiddleware.cs
+++ b/zipkin4net-aspnetcore/Criteo.Profiling.Tracing.Middleware/TracingMiddleware.cs
@@ -8,8 +8,13 @@ namespace Criteo.Profiling.Tracing.Middleware
     {
         public static void UseTracing(this IApplicationBuilder app, string serviceName)
         {
+            var extractor = new ZipkinHttpTraceExtractor();
             app.Use(async (context, next) => {
-                var trace = Trace.Create();
+                Trace trace;
+                if (!extractor.TryExtract(context.Request.Headers, out trace))
+                {
+                    trace = Trace.Create();
+                }
                 Trace.Current = trace;
                 trace.Record(Annotations.ServerRecv());
                 trace.Record(Annotations.ServiceName(serviceName));


### PR DESCRIPTION
If such headers exist, the trace is created from these values.