### PR TITLE
Tracing handler should not throw runtime exception

### DIFF
--- a/zipkin4net-aspnetcore/Criteo.Profiling.Tracing.Middleware/TracingHandler.cs
+++ b/zipkin4net-aspnetcore/Criteo.Profiling.Tracing.Middleware/TracingHandler.cs
@@ -10,14 +10,15 @@ namespace Criteo.Profiling.Tracing.Middleware
         private readonly ITraceInjector<HttpHeaders> _injector;
         private readonly string _serviceName;
 
-        public TracingHandler(string serviceName)
-        : this(new Middleware.ZipkinHttpTraceInjector(), serviceName)
+        public TracingHandler(string serviceName, HttpMessageHandler httpMessageHandler = null)
+        : this(new Middleware.ZipkinHttpTraceInjector(), serviceName, httpMessageHandler)
         {}
 
-        internal TracingHandler(ITraceInjector<HttpHeaders> injector, string serviceName)
+        internal TracingHandler(ITraceInjector<HttpHeaders> injector, string serviceName, HttpMessageHandler httpMessageHandler = null)
         {
             _injector = injector;
             _serviceName = serviceName;
+            InnerHandler = httpMessageHandler ?? new HttpClientHandler();
         }
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Without setting the Inner Handler, it throws.