### PR TITLE
Make the build fail if a sub-component fails to build

### DIFF
--- a/buildAndTest.sh
+++ b/buildAndTest.sh
@@ -6,6 +6,10 @@ for i in "${repositories[@]}"; do
     if [ -d $i ]; then
 	pushd $i
 	./buildAndTest.sh
+        if [ $? -ne 0 ]; then
+          echo "Compilation of $i failed, exiting"
+          exit 1
+        fi
 	popd
     else
 	echo "Can't build $i"


### PR DESCRIPTION
A bug was introduced when we switched to sub-projects, leading to
successful build status even if a compilation failed.