### PR TITLE
Makes the example interchangeable with others

### DIFF
--- a/zipkin4net-example/README.md
+++ b/zipkin4net-example/README.md
@@ -19,8 +19,8 @@ In order to build the example, you need to install a two things:
 # Running the example
 This example has two services: frontend and backend. They both report trace data to zipkin. To setup the demo, you need to start Frontend, Backend and Zipkin.
 
-Once the services are started, open http://localhost:5000/
-* This will call the backend (http://localhost:5001) and show the result, which defaults to a simple "Hello".
+Once the services are started, open http://localhost:8081/
+* This will call the backend (http://localhost:9000/api) and show the result, which defaults to printing the current date.
 
 Next, you can view traces that went through the backend via http://localhost:9411/?serviceName=backend
 * This is a locally run zipkin service which keeps traces in memory
@@ -37,13 +37,13 @@ In separate tabs or windows, start each of frontend and backend:
 ```bash
 $ pwd
 ~/zipkin4net/zipkin-example/frontend
-$ dotnet run http://*:5000
+$ dotnet run http://*:8081
 ```
 and
 ```bash
 $ pwd
 ~/zipkin4net/zipkin-example/backend
-$ dotnet run http://*:5001
+$ dotnet run http://*:9000
 ```
 
 
@@ -56,6 +56,6 @@ java -jar zipkin.jar
 
 ## Advanced setup
 
-If you want to use different ports that 5000 and 5001 for frontend and backend, you have to do two things:
+If you want to use different ports that 8081 and 9000 for frontend and backend, you have to do two things:
 * Edit the [configuration](https://github.com/criteo/zipkin4net/blob/master/zipkin4net-example/frontend/appSettings.json) and change the callServiceUrl to the desired backend url
 * Launch frontend and backend with the ports you want (the parameter just after dotnet run)

--- a/zipkin4net-example/backend/Startup.cs
+++ b/zipkin4net-example/backend/Startup.cs
@@ -16,8 +16,7 @@ namespace backend
         {
             app.Run(async (context) =>
             {
-                await Task.Delay(200);
-                await context.Response.WriteAsync("Hello");
+                await context.Response.WriteAsync(DateTime.Now.ToString());
             });
         }
     }

--- a/zipkin4net-example/frontend/Startup.cs
+++ b/zipkin4net-example/frontend/Startup.cs
@@ -18,7 +18,6 @@ namespace frontend
                 var callServiceUrl = config["callServiceUrl"];
                 using (var httpClient = new HttpClient(new TracingHandler(config["applicationName"])))
                 {
-                    await Task.Delay(100);
                     var response = await httpClient.GetAsync(callServiceUrl);
                     if (!response.IsSuccessStatusCode)
                     {

--- a/zipkin4net-example/frontend/appSettings.json
+++ b/zipkin4net-example/frontend/appSettings.json
@@ -1,4 +1,4 @@
 {
   "applicationName": "frontend",
-  "callServiceUrl": "http://localhost:5001"
+  "callServiceUrl": "http://localhost:9000/api"
 }


### PR DESCRIPTION
With some very slight tweaks, this example now has the same defaults as
other examples in Zipkin such as the below:

* https://github.com/openzipkin/sleuth-webmvc-example
* https://github.com/openzipkin/pyramid_zipkin-example
* https://github.com/openzipkin/zipkin-finagle-example
* https://github.com/openzipkin/zipkin-js-example

The impact is that you can swap frontend or backend for another language
and see polyglot in play!