### PR TITLE
Increase precision of sampling rate from 1e-4 to 1e-6

### DIFF
--- a/zipkin4net/Criteo.Profiling.Tracing.UTest/Sampling/T_Sampler.cs
+++ b/zipkin4net/Criteo.Profiling.Tracing.UTest/Sampling/T_Sampler.cs
@@ -53,12 +53,12 @@ namespace Criteo.Profiling.Tracing.UTest.Sampling
         [Test]
         public void SampleWorksAsExpected()
         {
-            var sampler = new DefaultSampler(NoSalt, 0.5f);
+            var sampler = new DefaultSampler(NoSalt, 0.000005f);
 
-            const int shouldTraceId = 4999;
+            const int shouldTraceId = 4;
             Assert.True(sampler.Sample(shouldTraceId));
 
-            const int notTraceId = 5000;
+            const int notTraceId = 5;
             Assert.False(sampler.Sample(notTraceId));
         }
 

--- a/zipkin4net/Criteo.Profiling.Tracing/Sampling/DefaultSampler.cs
+++ b/zipkin4net/Criteo.Profiling.Tracing/Sampling/DefaultSampler.cs
@@ -9,6 +9,7 @@ namespace Criteo.Profiling.Tracing.Sampling
         private readonly long _salt;
 
         private float _samplingRate;
+        private const int RatePrecision = 1000000;
 
         public DefaultSampler(long salt, float samplingRate = 0f)
         {
@@ -30,7 +31,7 @@ namespace Criteo.Profiling.Tracing.Sampling
 
         public bool Sample(long traceId)
         {
-            return Math.Abs(traceId ^ _salt) % 10000 < (_samplingRate * 10000);
+            return Math.Abs(traceId ^ _salt) % RatePrecision < (_samplingRate * RatePrecision);
         }
 
         private static bool IsValidSamplingRate(float rate)


### PR DESCRIPTION
Bug: The sampling rate can be set less than 1 to 10K traces sampled but will not be taken into account and will sample at least 1 to 10K traces.

Example: if the sampling rate is 1 to 100K and I sample 100K traces then I should only get 1 sampled. However, with the actual implementation, I would get 10 traces sampled.

Solution: Increase the sampling precision from 1 to 10K to 1 to 1M
Drawback: If the sampling rate is less than 1 to 1M, the sampling rate will still be 1 to 1M