### PR TITLE
Allow nuget to be compatible v4.5

### DIFF
--- a/zipkin4net/Criteo.Profiling.Tracing.UTest/Criteo.Profiling.Tracing.UTest.dotnetcore.csproj
+++ b/zipkin4net/Criteo.Profiling.Tracing.UTest/Criteo.Profiling.Tracing.UTest.dotnetcore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -31,5 +31,9 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 
 </Project>

--- a/zipkin4net/Criteo.Profiling.Tracing/Criteo.Profiling.Tracing.dotnetcore.csproj
+++ b/zipkin4net/Criteo.Profiling.Tracing/Criteo.Profiling.Tracing.dotnetcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <AssemblyName>Criteo.Profiling.Tracing</AssemblyName>
     <PackageId>Criteo.Profiling.Tracing</PackageId>
     <Title>Criteo.Profiling.Tracing</Title>
@@ -24,19 +24,26 @@
     <PackageLicenseUrl>https://github.com/criteo/zipkin4net/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.0" />
     <PackageReference Include="apache-thrift-netcore" Version="0.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 
 </Project>

--- a/zipkin4net/buildAndTest.sh
+++ b/zipkin4net/buildAndTest.sh
@@ -10,10 +10,14 @@ function check_availability() {
 }
 
 solution="zipkin4net.dotnetcore.sln"
+src="Criteo.Profiling.Tracing/Criteo.Profiling.Tracing.dotnetcore.csproj"
 tests="Criteo.Profiling.Tracing.UTest/Criteo.Profiling.Tracing.UTest.dotnetcore.csproj"
+benchmark="Criteo.Profiling.Tracing.Benchmark/Criteo.Profiling.Tracing.Benchmark.dotnetcore.csproj"
 
 check_availability "dotnet"
 
 dotnet restore  $solution   \
-&& dotnet build $solution   \
-&& dotnet test $tests       \
+&& dotnet build -f "netstandard1.5" $src         \
+&& dotnet build -f "netcoreapp1.1" $benchmark         \
+&& dotnet build -f "netcoreapp1.0" $tests        \
+&& dotnet test -f "netcoreapp1.0" $tests           \

--- a/zipkin4net/zipkin4net.dotnetcore.sln
+++ b/zipkin4net/zipkin4net.dotnetcore.sln
@@ -1,11 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Criteo.Profiling.Tracing.dotnetcore", "Criteo.Profiling.Tracing\Criteo.Profiling.Tracing.dotnetcore.csproj", "{95C0567E-8D23-40B2-BD4F-924F05EFE784}"
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.12
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Criteo.Profiling.Tracing.dotnetcore", "Criteo.Profiling.Tracing\Criteo.Profiling.Tracing.dotnetcore.csproj", "{95C0567E-8D23-40B2-BD4F-924F05EFE784}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Criteo.Profiling.Tracing.UTest.dotnetcore", "Criteo.Profiling.Tracing.UTest\Criteo.Profiling.Tracing.UTest.dotnetcore.csproj", "{223FF4E1-9A13-43FD-B350-3487A3C86CE1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Criteo.Profiling.Tracing.UTest.dotnetcore", "Criteo.Profiling.Tracing.UTest\Criteo.Profiling.Tracing.UTest.dotnetcore.csproj", "{223FF4E1-9A13-43FD-B350-3487A3C86CE1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Criteo.Profiling.Tracing.Benchmark.dotnetcore", "Criteo.Profiling.Tracing.Benchmark\Criteo.Profiling.Tracing.Benchmark.dotnetcore.csproj", "{58558293-438A-46DA-9886-A92026BDDF64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Criteo.Profiling.Tracing.Benchmark.dotnetcore", "Criteo.Profiling.Tracing.Benchmark\Criteo.Profiling.Tracing.Benchmark.dotnetcore.csproj", "{58558293-438A-46DA-9886-A92026BDDF64}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,39 +20,42 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x64.ActiveCfg = Debug|x64
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x64.Build.0 = Debug|x64
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x86.ActiveCfg = Debug|x86
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x86.Build.0 = Debug|x86
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x64.Build.0 = Debug|Any CPU
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Debug|x86.Build.0 = Debug|Any CPU
 		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|Any CPU.Build.0 = Release|Any CPU
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x64.ActiveCfg = Release|x64
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x64.Build.0 = Release|x64
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x86.ActiveCfg = Release|x86
-		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x86.Build.0 = Release|x86
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x64.ActiveCfg = Release|Any CPU
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x64.Build.0 = Release|Any CPU
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x86.ActiveCfg = Release|Any CPU
+		{95C0567E-8D23-40B2-BD4F-924F05EFE784}.Release|x86.Build.0 = Release|Any CPU
 		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x64.ActiveCfg = Debug|x64
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x64.Build.0 = Debug|x64
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x86.ActiveCfg = Debug|x86
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x86.Build.0 = Debug|x86
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x64.Build.0 = Debug|Any CPU
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Debug|x86.Build.0 = Debug|Any CPU
 		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x64.ActiveCfg = Release|x64
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x64.Build.0 = Release|x64
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x86.ActiveCfg = Release|x86
-		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x86.Build.0 = Release|x86
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x64.ActiveCfg = Release|Any CPU
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x64.Build.0 = Release|Any CPU
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x86.ActiveCfg = Release|Any CPU
+		{223FF4E1-9A13-43FD-B350-3487A3C86CE1}.Release|x86.Build.0 = Release|Any CPU
 		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x64.ActiveCfg = Debug|x64
-		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x64.Build.0 = Debug|x64
-		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x86.ActiveCfg = Debug|x86
-		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x86.Build.0 = Debug|x86
+		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x64.Build.0 = Debug|Any CPU
+		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{58558293-438A-46DA-9886-A92026BDDF64}.Debug|x86.Build.0 = Debug|Any CPU
 		{58558293-438A-46DA-9886-A92026BDDF64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58558293-438A-46DA-9886-A92026BDDF64}.Release|Any CPU.Build.0 = Release|Any CPU
-		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x64.ActiveCfg = Release|x64
-		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x64.Build.0 = Release|x64
-		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x86.ActiveCfg = Release|x86
-		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x86.Build.0 = Release|x86
+		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x64.ActiveCfg = Release|Any CPU
+		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x64.Build.0 = Release|Any CPU
+		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x86.ActiveCfg = Release|Any CPU
+		{58558293-438A-46DA-9886-A92026BDDF64}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Travis will still target only netstandard for compatibility issues. However, the created nuget will be compatible net45 and netstandard.

Fixes #94 