### PR TITLE
Force serialization of timestamps to UTC.

### DIFF
--- a/zipkin4net/Criteo.Profiling.Tracing.UTest/Utils/T_TimeUtils.cs
+++ b/zipkin4net/Criteo.Profiling.Tracing.UTest/Utils/T_TimeUtils.cs
@@ -20,6 +20,19 @@ namespace Criteo.Profiling.Tracing.UTest.Utils
 
             Assert.AreEqual(expectedTimestamp, timestamp);
         }
+
+        [Test]
+        public void TimestampGenerationIsCorrectInLocal()
+        {
+            // from timestampgenerator.com, expressed in microseconds
+            const long expectedTimestamp = 636981516000000;
+
+            var utcDateTime = new DateTime(1990, 3, 9, 11, 18, 36, DateTimeKind.Local).Add(TimeZoneInfo.Local.BaseUtcOffset);
+
+            var timestamp = utcDateTime.ToUnixTimestamp();
+
+            Assert.AreEqual(expectedTimestamp, timestamp);
+        }
     }
 
 }

--- a/zipkin4net/Criteo.Profiling.Tracing/Utils/TimeUtils.cs
+++ b/zipkin4net/Criteo.Profiling.Tracing/Utils/TimeUtils.cs
@@ -22,7 +22,7 @@ namespace Criteo.Profiling.Tracing.Utils
         /// <returns></returns>
         public static long ToUnixTimestamp(this DateTime utcDateTime)
         {
-            return (long)(utcDateTime.Subtract(Epoch).TotalMilliseconds * 1000L);
+            return (long)(utcDateTime.ToUniversalTime().Subtract(Epoch).TotalMilliseconds * 1000L);
         }
     }
 }


### PR DESCRIPTION
This pull requests is to enforce serialization of timestamps in UTC.
Issue #100  raised the problem that client could provide Local DateTime and they would be serialized as is. Here, we make sure to use a UTC DateTime when DateTime source is local or undefined.