### PR TITLE
Move TracingHandler to zipkin4net.

### DIFF
--- a/zipkin4net/Criteo.Profiling.Tracing/Criteo.Profiling.Tracing.csproj
+++ b/zipkin4net/Criteo.Profiling.Tracing/Criteo.Profiling.Tracing.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Transport\ZipkinHttpTraceInjector.cs" />
     <Compile Include="Transport\ITraceExtractor.cs" />
     <Compile Include="Transport\ITraceInjector.cs" />
+    <Compile Include="Transport\Http\TracingHandler.cs" />
     <Compile Include="Utils\NumberUtils.cs" />
     <Compile Include="Utils\RandomUtils.cs" />
     <Compile Include="Tracers\Zipkin\thrift_gen\gen-csharp\Criteo\Profiling\Tracing\Tracers\Zipkin\Thrift\Annotation.cs" />

--- a/zipkin4net/Criteo.Profiling.Tracing/Transport/Http/TracingHandler.cs
+++ b/zipkin4net/Criteo.Profiling.Tracing/Transport/Http/TracingHandler.cs
@@ -1,11 +1,8 @@
-using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
-using Criteo.Profiling.Tracing.Transport;
 
-namespace Criteo.Profiling.Tracing.Middleware
+namespace Criteo.Profiling.Tracing.Transport.Http
 {
-    [Obsolete("Use Criteo.Profiling.Tracing.Transport.Http.TracingHandler")]
     public class TracingHandler : DelegatingHandler
     {
         private readonly ITraceInjector _injector;
@@ -13,7 +10,7 @@ namespace Criteo.Profiling.Tracing.Middleware
 
         public TracingHandler(string serviceName, HttpMessageHandler httpMessageHandler = null)
         : this(new ZipkinHttpTraceInjector(), serviceName, httpMessageHandler)
-        {}
+        { }
 
         internal TracingHandler(ITraceInjector injector, string serviceName, HttpMessageHandler httpMessageHandler = null)
         {


### PR DESCRIPTION
TracingHandler has nothing to do with asp.net core and is using standard packages. It seems to be a part of the core components now.