### PR TITLE
Unit test on duration is now correct.

### DIFF
--- a/Src/zipkin4net/Tests/Tracers/Zipkin/T_Span.cs
+++ b/Src/zipkin4net/Tests/Tracers/Zipkin/T_Span.cs
@@ -60,7 +60,7 @@ namespace zipkin4net.UTest.Tracers.Zipkin
         [Test]
         public void ClientDurationIsPreferredOverServer()
         {
-            var spanState = new SpanState(1, 0, 2, SpanFlags.None);
+            var spanState = new SpanState(1, null, 2, SpanFlags.None);
             var span = new Span(spanState, TimeUtils.UtcNow);
             const int offset = 10;
 


### PR DESCRIPTION
Duration of client should be preferred over server duration but the test did not end up having a server duration