### PR TITLE
JSONSpanSerializer add ToEscaped while serializing serviceName, span.Name, binaryAnnotation.Value

### DIFF
--- a/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
@@ -46,7 +46,7 @@ namespace zipkin4net.Tracers.Zipkin
             writer.Write(openingBrace);
             writer.WriteField(id, NumberUtils.EncodeLongToLowerHexString(span.SpanState.SpanId));
             writer.Write(comma);
-            writer.WriteField(name, span.Name ?? SerializerUtils.DefaultRpcMethodName);
+            writer.WriteField(name, span.Name == null ? SerializerUtils.ToEscaped(span.Name) : SerializerUtils.DefaultRpcMethodName);
             if (span.Annotations.Count != 0)
             {
                 writer.Write(comma);
@@ -100,7 +100,7 @@ namespace zipkin4net.Tracers.Zipkin
             writer.Write(openingBrace);
             writer.WriteField(key, binaryAnnotation.Key);
             writer.Write(comma);
-            writer.WriteField(value, Encoding.UTF8.GetString(binaryAnnotation.Value));
+            writer.WriteField(value, SerializerUtils.ToEscaped(Encoding.UTF8.GetString(binaryAnnotation.Value)));
             writer.Write(comma);
             writer.WriteAnchor(endpoint);
             SerializeEndPoint(writer, endPoint, serviceName);
@@ -126,7 +126,7 @@ namespace zipkin4net.Tracers.Zipkin
             writer.Write(comma);
             writer.WriteField(port, (short)endPoint.Port);
             writer.Write(comma);
-            writer.WriteField(JSONSpanSerializer.serviceName, serviceName);
+            writer.WriteField(JSONSpanSerializer.serviceName, SerializerUtils.ToEscaped(serviceName));
             writer.Write(closingBrace);
         }
     }

--- a/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
@@ -46,7 +46,7 @@ namespace zipkin4net.Tracers.Zipkin
             writer.Write(openingBrace);
             writer.WriteField(id, NumberUtils.EncodeLongToLowerHexString(span.SpanState.SpanId));
             writer.Write(comma);
-            writer.WriteField(name, span.Name == null ? SerializerUtils.ToEscaped(span.Name) : SerializerUtils.DefaultRpcMethodName);
+            writer.WriteField(name, span.Name != null ? SerializerUtils.ToEscaped(span.Name) : SerializerUtils.DefaultRpcMethodName);
             if (span.Annotations.Count != 0)
             {
                 writer.Write(comma);
@@ -112,7 +112,7 @@ namespace zipkin4net.Tracers.Zipkin
             writer.Write(openingBrace);
             writer.WriteField(timestamp, annotation.Timestamp.ToUnixTimestamp());
             writer.Write(comma);
-            writer.WriteField(value, annotation.Value);
+            writer.WriteField(value, SerializerUtils.ToEscaped(annotation.Value));
             writer.Write(comma);
             writer.WriteAnchor(endpoint);
             SerializeEndPoint(writer, endPoint, serviceName);

--- a/Src/zipkin4net/Src/Tracers/Zipkin/SerializerUtils.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/SerializerUtils.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Text;
 using zipkin4net.Utils;
 
 namespace zipkin4net.Tracers.Zipkin
@@ -61,6 +63,47 @@ namespace zipkin4net.Tracers.Zipkin
             }
 
             return new IPEndPoint(address, 0);
+        }
+
+        /// <summary>
+        /// string value transform to a escaped string
+        /// </summary>
+        /// <param name="input">original string value</param>
+        /// <returns>escaped string value</returns>
+        public static string ToEscaped(string input)
+        {
+            if (input == null)
+                return null;
+            var literal = new StringBuilder(input.Length + 2);
+            foreach (var c in input)
+            {
+                switch (c)
+                {
+                    //case '\'': literal.Append(@"\'"); break;
+                    case '\"': literal.Append("\\\""); break;
+                    case '\\': literal.Append(@"\\"); break;
+                    case '\0': literal.Append(@"\0"); break;
+                    case '\a': literal.Append(@"\a"); break;
+                    case '\b': literal.Append(@"\b"); break;
+                    case '\f': literal.Append(@"\f"); break;
+                    case '\n': literal.Append(@"\n"); break;
+                    case '\r': literal.Append(@"\r"); break;
+                    case '\t': literal.Append(@"\t"); break;
+                    case '\v': literal.Append(@"\v"); break;
+                    default:
+                        if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.Control)
+                        {
+                            literal.Append(c);
+                        }
+                        else
+                        {
+                            literal.Append(@"\u");
+                            literal.Append(((ushort)c).ToString("x4"));
+                        }
+                        break;
+                }
+            }
+            return literal.ToString();
         }
     }
 }

--- a/Src/zipkin4net/Tests/Utils/T_SerializerUtils.cs
+++ b/Src/zipkin4net/Tests/Utils/T_SerializerUtils.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using zipkin4net.Tracers.Zipkin;
+
+namespace zipkin4net.Tests.dotnetcore.Utils
+{
+    [TestFixture]
+    internal class T_SerializerUtils
+    {
+        [Test]
+        public void ToEscaped()
+        {
+            string testString = "\"testString\"";
+            string testString2 = "\"!@#$%^&*()\a\b\0\f\n\r\t\v";
+            Assert.AreEqual(SerializerUtils.ToEscaped(testString), "\\\"testString\\\"");
+            Assert.AreEqual(SerializerUtils.ToEscaped(testString2), "\\\"!@#$%^&*()\\a\\b\\0\\f\\n\\r\\t\\v");
+
+        }
+    }
+}


### PR DESCRIPTION
JSONSpanSerializer add ToEscaped while serializing serviceName, span.Name, binaryAnnotation.Value
Fix bug https://github.com/openzipkin/zipkin4net/issues/156