### PR TITLE
Fix JSON Boolean serialisation

### DIFF
--- a/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
@@ -175,7 +175,7 @@ namespace zipkin4net.Tracers.Zipkin
         )
         {
             WriteAnchor(writer, fieldName);
-            writer.Write(fieldValue);
+            writer.Write(fieldValue ? "true" : "false");
         }
 
         internal static void WriteField


### PR DESCRIPTION
The default `TextWriter` serialisation for Boolean values is `True` and `False`  (see [here](https://github.com/dotnet/corefx/blob/b7435702fe02e542f9dc35cccc7a795eef100bb2/src/Common/src/CoreLib/System/IO/TextWriter.cs#L189-L192)), which isn't valid JSON.

This PR changes the serialisation to `true` and `false`.