### PR TITLE
allow to configure what will be the rpc used

### DIFF
--- a/Src/zipkin4net.middleware.aspnetcore/Src/TracingMiddleware.cs
+++ b/Src/zipkin4net.middleware.aspnetcore/Src/TracingMiddleware.cs
@@ -1,14 +1,17 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using System;
 using zipkin4net.Propagation;
 
 namespace zipkin4net.Middleware
 {
     public static class TracingMiddleware
     {
-        public static void UseTracing(this IApplicationBuilder app, string serviceName)
+        public static void UseTracing(this IApplicationBuilder app, string serviceName,
+            Func<HttpContext, string> getRpc = null)
         {
+            getRpc = getRpc ?? (context => context.Request.Method);
             var extractor = Propagations.B3String.Extractor<IHeaderDictionary>((carrier, key) => carrier[key]);
             app.Use(async (context, next) =>
             {
@@ -17,7 +20,7 @@ namespace zipkin4net.Middleware
                 
                 var trace = traceContext == null ? Trace.Create() : Trace.CreateFromId(traceContext);
                 Trace.Current = trace;
-                using (var serverTrace = new ServerTrace(serviceName, request.Method))
+                using (var serverTrace = new ServerTrace(serviceName, getRpc(context)))
                 {
                     trace.Record(Annotations.Tag("http.host", request.Host.ToString()));
                     trace.Record(Annotations.Tag("http.uri", UriHelper.GetDisplayUrl(request)));

--- a/Src/zipkin4net.middleware.owin/Src/Extensions/OwinExtensions.cs
+++ b/Src/zipkin4net.middleware.owin/Src/Extensions/OwinExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Owin;
+using System;
 using zipkin4net.Middleware;
 using zipkin4net.Propagation;
 
@@ -6,10 +7,10 @@ namespace Owin
 {
     public static class OwinExtensions
     {
-        public static IAppBuilder UseZipkinTracer(this IAppBuilder appBuilder, string serviceName, IExtractor<IHeaderDictionary> traceExtractor)
-            => appBuilder.Use<ZipkinMiddleware>(serviceName, traceExtractor);
+        public static IAppBuilder UseZipkinTracer(this IAppBuilder appBuilder, string serviceName, IExtractor<IHeaderDictionary> traceExtractor, Func<IOwinContext, string> getRpc = null)
+            => appBuilder.Use<ZipkinMiddleware>(serviceName, traceExtractor, getRpc);
 
-        public static IAppBuilder UseZipkinTracer(this IAppBuilder appBuilder, string serviceName)
-            => appBuilder.UseZipkinTracer(serviceName, Propagations.B3String.Extractor((IHeaderDictionary carrier, string key) => string.Join(",", carrier[key])));
+        public static IAppBuilder UseZipkinTracer(this IAppBuilder appBuilder, string serviceName, Func<IOwinContext, string> getRpc = null)
+            => appBuilder.UseZipkinTracer(serviceName, Propagations.B3String.Extractor((IHeaderDictionary carrier, string key) => string.Join(",", carrier[key])), getRpc);
     }
 }

--- a/Src/zipkin4net.middleware.owin/Tests/Helpers/OwinHelper.cs
+++ b/Src/zipkin4net.middleware.owin/Tests/Helpers/OwinHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Owin.Testing;
+﻿using Microsoft.Owin;
+using Microsoft.Owin.Testing;
 using Owin;
 using System;
 using System.Net.Http;
@@ -18,12 +19,12 @@ namespace zipkin4net.Middleware.Tests.Helpers
                 }
             }
         }
-        internal static Action<IAppBuilder> DefaultStartup(string serviceName)
+        internal static Action<IAppBuilder> DefaultStartup(string serviceName, Func<IOwinContext, string> getRpc = null)
         {
             return
                 app =>
                 {
-                    app.UseZipkinTracer(serviceName);
+                    app.UseZipkinTracer(serviceName, getRpc);
 
                     app.Run(async context =>
                     {


### PR DESCRIPTION
Hello,

we found that only have HttpMethod as rpc is mostly useless specialy at tracingHandler level.
This allow us to configure as we want what we put in rpc.

