### PR TITLE
Fix owin tests flakiness on appveyor

### DIFF
--- a/Src/zipkin4net/Src/Properties/AssemblyInfo.cs
+++ b/Src/zipkin4net/Src/Properties/AssemblyInfo.cs
@@ -48,5 +48,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 [assembly: InternalsVisibleTo("zipkin4net.UTest")]
+[assembly: InternalsVisibleTo("zipkin4netmiddleware.owin.UTest")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 


### PR DESCRIPTION
IRecordDispatcher used implentation was async, leading to a weird race condition.
On top of that, TraceManager was not stopped on TearDown