### PR TITLE
Make Record internal.

### DIFF
--- a/Src/zipkin4net/Src/Record.cs
+++ b/Src/zipkin4net/Src/Record.cs
@@ -3,7 +3,7 @@ using zipkin4net.Annotation;
 
 namespace zipkin4net
 {
-    public sealed class Record
+    internal sealed class Record
     {
         private const string DatetimeFormat = "MMdd HH:mm:ss.fff";
 


### PR DESCRIPTION
It's only used by internal methods and should not be exposed to clients.

There's no need to put it Obsolete first as the only usages of it are not exposed to the final user