### PR TITLE
Serialise long as a JSON number, not string

### DIFF
--- a/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/JSONSpanSerializer.cs
@@ -198,9 +198,7 @@ namespace zipkin4net.Tracers.Zipkin
         )
         {
             WriteAnchor(writer, fieldName);
-            writer.Write(quotes);
             writer.Write(fieldValue);
-            writer.Write(quotes);
         }
 
         internal static void WriteAnchor(this StreamWriter writer, string anchor)


### PR DESCRIPTION
Although JavaScript numbers are not the same as the C# `long` data type (so serialising as a number may lose precision), some Zipkin collectors (e.g., Jaeger) will refuse to deserialise a number that is encoded as a string.