### PR TITLE
Make IRecordDispatcher public and exchangeable

### DIFF
--- a/Src/zipkin4net/Src/Dispatcher/IRecordDispatcher.cs
+++ b/Src/zipkin4net/Src/Dispatcher/IRecordDispatcher.cs
@@ -1,10 +1,15 @@
 ﻿namespace zipkin4net.Dispatcher
 {
-    internal interface IRecordDispatcher
+    public interface IRecordDispatcher
     {
-
+        /// <summary>
+        /// Stops the dispatcher.
+        /// </summary>
         void Stop();
-
+        /// <summary>
+        /// Dispatches a record to the registered tracers.
+        /// </summary>
+        /// <returns>True if the record was dispatched. Otherwise false.</returns>
         bool Dispatch(Record record);
 
     }

--- a/Src/zipkin4net/Src/Dispatcher/InOrderAsyncActionBlockDispatcher.cs
+++ b/Src/zipkin4net/Src/Dispatcher/InOrderAsyncActionBlockDispatcher.cs
@@ -7,7 +7,7 @@ namespace zipkin4net.Dispatcher
     /// <summary>
     /// Dispatch messages asynchronously in order using an ActionBlock
     /// </summary>
-    internal class InOrderAsyncActionBlockDispatcher : IRecordDispatcher
+    public class InOrderAsyncActionBlockDispatcher : IRecordDispatcher
     {
         private readonly ActionBlock<Record> _actionBlock;
         private readonly TimeSpan _timeoutOnStop;

--- a/Src/zipkin4net/Src/Dispatcher/InOrderAsyncQueueDispatcher.cs
+++ b/Src/zipkin4net/Src/Dispatcher/InOrderAsyncQueueDispatcher.cs
@@ -8,7 +8,7 @@ namespace zipkin4net.Dispatcher
     /// <summary>
     /// Dispatch messages asynchronously in order using a concurrent queue and a consumer task
     /// </summary>
-    internal class InOrderAsyncQueueDispatcher : IRecordDispatcher
+    public class InOrderAsyncQueueDispatcher : IRecordDispatcher
     {
         private readonly Action<Record> _pushToTracers;
         private readonly int _maxCapacity;

--- a/Src/zipkin4net/Src/TraceManager.cs
+++ b/Src/zipkin4net/Src/TraceManager.cs
@@ -61,7 +61,11 @@ namespace zipkin4net
             return Start(logger, new InOrderAsyncQueueDispatcher(Push));
         }
 
-        internal static bool Start(ILogger logger, IRecordDispatcher dispatcher)
+        /// <summary>
+        /// Start tracing, records will be forwarded to the registered tracers, using the provided dispatcher.
+        /// </summary>
+        /// <returns>True if successfully started, false if error or the service was already running.</returns>
+        public static bool Start(ILogger logger, IRecordDispatcher dispatcher)
         {
             if (Interlocked.CompareExchange(ref _status, (int)Status.Started, (int)Status.Stopped) ==
                       (int)Status.Stopped)


### PR DESCRIPTION
#208 

Made all dispatcher types (except `VoidDispatcher`) and the internal `TraceManager.Start()` overload public.

Didn't change the package version. Should this be considered a minor or patch release?