### PR TITLE
Support for IIS hosted applications using OWIN middleware

### DIFF
--- a/Src/zipkin4net/Src/zipkin4net.csproj
+++ b/Src/zipkin4net/Src/zipkin4net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard1.6;net451;net452;net46;net461;net462</TargetFrameworks>
     <AssemblyName>zipkin4net</AssemblyName>
     <PackageId>zipkin4net</PackageId>
     <Title>zipkin4net</Title>
@@ -33,6 +33,12 @@
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net451'">
+	<Reference Include="System.Web" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net451'">
+	<DefineConstants>$(DefineConstants);NETFULL</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Apache.Thrift" Version="1.0.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />


### PR DESCRIPTION
When using OWIN middleware with IIS integrated pipeline the TracingHandler doesn't add any headers for outgoing requests.

This is because it cannot get the current trace, Trace.Current always returns null.

I believe this is due to the way in which OWIN middleware executes when using IIS.
https://docs.microsoft.com/en-us/aspnet/aspnet/overview/owin-and-katana/owin-middleware-in-the-iis-integrated-pipeline

Basically we have a different CallContext in the TracingHandler so the current trace (set in the middleware) cannot be retrieved.

Best solution seems to be to use the HttpContext instead of the CallContext.