### PR TITLE
Annotation's ToString provides all extra data

### DIFF
--- a/Src/zipkin4net/Src/Annotation/ServerAddr.cs
+++ b/Src/zipkin4net/Src/Annotation/ServerAddr.cs
@@ -11,6 +11,11 @@ namespace zipkin4net.Annotation
             ServiceName = serviceName;
         }
 
+        public override string ToString()
+        {
+            return string.Format("{0}: {1}/{2}", GetType().Name, ServiceName, Endpoint);
+        }
+
         public override void Accept(IAnnotationVisitor visitor)
         {
             visitor.Visit(this);

--- a/Src/zipkin4net/Src/Annotation/TagAnnotation.cs
+++ b/Src/zipkin4net/Src/Annotation/TagAnnotation.cs
@@ -13,7 +13,7 @@
 
         public override string ToString()
         {
-            return string.Format("{0}: {1} [{2} {3}]", GetType().Name, Key, Value, Value.GetType());
+            return string.Format("{0}: {1}:{2}", GetType().Name, Key, Value);
         }
 
         public void Accept(IAnnotationVisitor visitor)

--- a/Src/zipkin4net/Src/Annotation/TagAnnotation.cs
+++ b/Src/zipkin4net/Src/Annotation/TagAnnotation.cs
@@ -13,7 +13,7 @@
 
         public override string ToString()
         {
-            return string.Format("{0}: {1} [{2}]", GetType().Name, Key, Value.GetType());
+            return string.Format("{0}: {1} [{2} {3}]", GetType().Name, Key, Value, Value.GetType());
         }
 
         public void Accept(IAnnotationVisitor visitor)

--- a/Src/zipkin4net/Tests/T_Annotations.cs
+++ b/Src/zipkin4net/Tests/T_Annotations.cs
@@ -1,4 +1,5 @@
-﻿using zipkin4net.Annotation;
+﻿using System.Net;
+using zipkin4net.Annotation;
 using NUnit.Framework;
 
 namespace zipkin4net.UTest
@@ -26,6 +27,23 @@ namespace zipkin4net.UTest
             Assert.IsInstanceOf<ConsumerStop>(Annotations.ConsumerStop());
             Assert.IsInstanceOf<ProducerStart>(Annotations.ProducerStart());
             Assert.IsInstanceOf<ProducerStop>(Annotations.ProducerStop());
+            Assert.IsInstanceOf<LocalOperationStart>(Annotations.LocalOperationStart(""));
+            Assert.IsInstanceOf<LocalOperationStop>(Annotations.LocalOperationStop());
+        }
+
+        [Test]
+        public void ToStringWriteExtraDataInAdditionToType()
+        {
+            Assert.AreEqual("TagAnnotation: sampleTagKey [sampleTagValue System.String]", Annotations.Tag("sampleTagKey", "sampleTagValue").ToString());
+            Assert.AreEqual("Rpc: GET", Annotations.Rpc("GET").ToString());
+            Assert.AreEqual("ServiceName: sampleName", Annotations.ServiceName("sampleName").ToString());
+            Assert.AreEqual("Event: sampleName", Annotations.Event("sampleName").ToString());
+            Assert.AreEqual("LocalOperationStart: sampleName", Annotations.LocalOperationStart("sampleName").ToString());
+
+            var samIpEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 80);
+            Assert.AreEqual("ClientAddr: 127.0.0.1:80", Annotations.ClientAddr(samIpEndPoint).ToString());
+            Assert.AreEqual("ServerAddr: sampleName/127.0.0.1:80", Annotations.ServerAddr("sampleName", samIpEndPoint).ToString());
+            Assert.AreEqual("MessageAddr: sampleName/127.0.0.1:80", Annotations.MessageAddr("sampleName", samIpEndPoint).ToString());
         }
 
     }

--- a/Src/zipkin4net/Tests/T_Annotations.cs
+++ b/Src/zipkin4net/Tests/T_Annotations.cs
@@ -34,7 +34,7 @@ namespace zipkin4net.UTest
         [Test]
         public void ToStringWriteExtraDataInAdditionToType()
         {
-            Assert.AreEqual("TagAnnotation: sampleTagKey [sampleTagValue System.String]", Annotations.Tag("sampleTagKey", "sampleTagValue").ToString());
+            Assert.AreEqual("TagAnnotation: sampleTagKey:sampleTagValue", Annotations.Tag("sampleTagKey", "sampleTagValue").ToString());
             Assert.AreEqual("Rpc: GET", Annotations.Rpc("GET").ToString());
             Assert.AreEqual("ServiceName: sampleName", Annotations.ServiceName("sampleName").ToString());
             Assert.AreEqual("Event: sampleName", Annotations.Event("sampleName").ToString());


### PR DESCRIPTION
For example, while using ConsoleTracer for debugging, we see only
`"TagAnnotation: http.host [System.String]" `
without info about host, now it becomes
`"TagAnnotation: http.host [127.0.0.1 System.String]"`

Same is done for some other Annotations with taking into account previously used format.

Btw, i don't see a point for showing [System.String] and propose to use the following format:
`"TagAnnotation: http.host:127.0.0.1"` or `"TagAnnotation: http.host=127.0.0.1"`
