### PR TITLE
Request without host throw exception

### DIFF
--- a/Src/zipkin4net.middleware.aspnetcore/Src/TracingMiddleware.cs
+++ b/Src/zipkin4net.middleware.aspnetcore/Src/TracingMiddleware.cs
@@ -25,8 +25,8 @@ namespace zipkin4net.Middleware
                     if (request.Host.HasValue)
                     {
                         trace.Record(Annotations.Tag("http.host", request.Host.ToString()));
+                        trace.Record(Annotations.Tag("http.uri", UriHelper.GetDisplayUrl(request)));
                     }
-                    trace.Record(Annotations.Tag("http.uri", UriHelper.GetDisplayUrl(request)));
                     trace.Record(Annotations.Tag("http.path", request.Path));
                     await serverTrace.TracedActionAsync(next());
                 }


### PR DESCRIPTION
The request without host throw exception. Tested with asp.net core middleware and http1.0 request.

8e73b3c9 partly fixed it, but UriHelper.GetDisplayUrl implicitly uses host too, so throwing NullReferenceException.

https://github.com/aspnet/Home/issues/2718 is the root of problem, check for details.

