### PR TITLE
Check if current trace is null in ClientTrace.Error

### DIFF
--- a/Src/zipkin4net/Src/ClientTrace.cs
+++ b/Src/zipkin4net/Src/ClientTrace.cs
@@ -27,7 +27,7 @@ namespace zipkin4net
 
         public virtual void Error(Exception ex)
         {
-            Trace.RecordAnnotation(Annotations.Tag("error", ex.Message));
+            Trace?.RecordAnnotation(Annotations.Tag("error", ex.Message));
         }
 
         public void Dispose()


### PR DESCRIPTION
TracingHandler throws NullReferenceException when current trace is null, as in the example below.
```csharp
static async Task Main(string[] args)
{
    using (var client = new HttpClient(new TracingHandler("service-name")))
    {
        await client.GetAsync("http://non-existent-host"); // throws NullReferenceException
    }
}
```