### PR TITLE
[MCC-582025] add producer and consumer duration

### DIFF
--- a/Src/zipkin4net/Src/Tracers/Zipkin/Span.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/Span.cs
@@ -122,7 +122,7 @@ namespace zipkin4net.Tracers.Zipkin
                 startTime = annotation.Timestamp;
             }
 
-            if (startTime == default)
+            if (startTime == default(DateTime))
                 return;
 
             SpanStarted = startTime;

--- a/Src/zipkin4net/Src/Tracers/Zipkin/Span.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/Span.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Resources;
 using zipkin4net.Tracers.Zipkin.Thrift;
 
 namespace zipkin4net.Tracers.Zipkin
@@ -103,27 +102,27 @@ namespace zipkin4net.Tracers.Zipkin
                 startTime = binaryAnnotation.Timestamp;
             }
             // Else for producer duration
-            else if (TryGetProducerStart(out annotation))
+            else if (TryGetAnnotation(zipkinCoreConstants.MESSAGE_SEND, out annotation))
             {
                 startTime = annotation.Timestamp;
             }
             // Else for consumer duration
-            else if (TryGetConsumerStart(out annotation))
+            else if (TryGetAnnotation(zipkinCoreConstants.MESSAGE_RECV, out annotation))
             {
                 startTime = annotation.Timestamp;
             }
             // Else for the client duration
-            else if (TryGetClientSend(out annotation))
+            else if (TryGetAnnotation(zipkinCoreConstants.CLIENT_SEND, out annotation))
             {
                 startTime = annotation.Timestamp;
             }
             // Else look for server annotations
-            else if(IsRoot && TryGetServerRecv(out annotation))
+            else if (IsRoot && TryGetAnnotation(zipkinCoreConstants.SERVER_RECV, out annotation))
             {
                 startTime = annotation.Timestamp;
             }
 
-            if (startTime == default(DateTime))
+            if (startTime == default)
                 return;
 
             SpanStarted = startTime;
@@ -144,26 +143,6 @@ namespace zipkin4net.Tracers.Zipkin
         {
             localComponentBinAnnotation = BinaryAnnotations.FirstOrDefault(a => a.Key.Equals(zipkinCoreConstants.LOCAL_COMPONENT));
             return localComponentBinAnnotation != default(BinaryAnnotation);
-        }
-
-        private bool TryGetProducerStart(out ZipkinAnnotation producerStartAnnotation)
-        {
-            return TryGetAnnotation(zipkinCoreConstants.MESSAGE_SEND, out producerStartAnnotation);
-        }
-
-        private bool TryGetConsumerStart(out ZipkinAnnotation consumerStartAnnotation)
-        {
-            return TryGetAnnotation(zipkinCoreConstants.MESSAGE_RECV, out consumerStartAnnotation);
-        }
-
-        private bool TryGetClientSend(out ZipkinAnnotation clientSendAnnotation)
-        {
-            return TryGetAnnotation(zipkinCoreConstants.CLIENT_SEND, out clientSendAnnotation);
-        }
-
-        private bool TryGetServerRecv(out ZipkinAnnotation serverRecvAnnotation)
-        {
-            return TryGetAnnotation(zipkinCoreConstants.SERVER_RECV, out serverRecvAnnotation);
         }
 
         private bool TryGetAnnotation(string annotationType, out ZipkinAnnotation annotation)

--- a/Src/zipkin4net/Src/Tracers/Zipkin/Span.cs
+++ b/Src/zipkin4net/Src/Tracers/Zipkin/Span.cs
@@ -102,6 +102,16 @@ namespace zipkin4net.Tracers.Zipkin
             {
                 startTime = binaryAnnotation.Timestamp;
             }
+            // Else for producer duration
+            else if (TryGetProducerStart(out annotation))
+            {
+                startTime = annotation.Timestamp;
+            }
+            // Else for consumer duration
+            else if (TryGetConsumerStart(out annotation))
+            {
+                startTime = annotation.Timestamp;
+            }
             // Else for the client duration
             else if (TryGetClientSend(out annotation))
             {
@@ -134,6 +144,16 @@ namespace zipkin4net.Tracers.Zipkin
         {
             localComponentBinAnnotation = BinaryAnnotations.FirstOrDefault(a => a.Key.Equals(zipkinCoreConstants.LOCAL_COMPONENT));
             return localComponentBinAnnotation != default(BinaryAnnotation);
+        }
+
+        private bool TryGetProducerStart(out ZipkinAnnotation producerStartAnnotation)
+        {
+            return TryGetAnnotation(zipkinCoreConstants.MESSAGE_SEND, out producerStartAnnotation);
+        }
+
+        private bool TryGetConsumerStart(out ZipkinAnnotation consumerStartAnnotation)
+        {
+            return TryGetAnnotation(zipkinCoreConstants.MESSAGE_RECV, out consumerStartAnnotation);
         }
 
         private bool TryGetClientSend(out ZipkinAnnotation clientSendAnnotation)

--- a/Src/zipkin4net/Tests/Tracers/Zipkin/T_Span.cs
+++ b/Src/zipkin4net/Tests/Tracers/Zipkin/T_Span.cs
@@ -47,13 +47,17 @@ namespace zipkin4net.UTest.Tracers.Zipkin
             }
         }
 
-        [Test]
-        public void SpanDoesntHaveDurationIfIncomplete()
+        [TestCase(zipkinCoreConstants.MESSAGE_SEND, true)]
+        [TestCase(zipkinCoreConstants.MESSAGE_RECV, true)]
+        [TestCase(zipkinCoreConstants.CLIENT_SEND, true)]
+        [TestCase(zipkinCoreConstants.SERVER_RECV, true)]
+        [TestCase(zipkinCoreConstants.SERVER_SEND, false)]
+        [TestCase(zipkinCoreConstants.CLIENT_RECV, false)]
+        public void SpanHasDurationForSelectedAnnotationOnly(string annotationType, bool shouldHaveDuration)
         {
             var offset = TimeSpan.FromMilliseconds(10);
 
-            Assert.False(GetSpanDuration(offset, zipkinCoreConstants.SERVER_SEND).HasValue);
-            Assert.False(GetSpanDuration(offset, zipkinCoreConstants.CLIENT_RECV).HasValue);
+            Assert.AreEqual(GetSpanDuration(offset, annotationType).HasValue, shouldHaveDuration);
         }
 
 


### PR DESCRIPTION
Problem: `PRODUCER` and `CONSUMER` spans don't have duration

Fix: Add missing duration if spans are of type `PRODUCER` and `CONSUMER`

Before fix:
![image](https://user-images.githubusercontent.com/10608964/77893934-8a19a080-72af-11ea-9158-1ede78816ca7.png)
```json
{
    "traceId": "94e28dc9de676b4e",
    "id": "ae0f80cea8c7bbdc",
    "kind": "PRODUCER",
    "name": "send message",
    "timestamp": 1585558441828882,
    "localEndpoint": {
        "serviceName": "sample-producer-app",
        "ipv4": "10.152.25.139"
    }
},
{
    "traceId": "94e28dc9de676b4e",
    "parentId": "ae0f80cea8c7bbdc",
    "id": "f2b9e8d7ea1be767",
    "kind": "CONSUMER",
    "name": "process message",
    "timestamp": 1585558443351661,
    "localEndpoint": {
        "serviceName": "sample-consumer-app",
        "ipv4": "10.152.25.139"
    },
    "tags": {
        "sample-tag": "xxxxxxx"
    }
}
```

After fix:
![image](https://user-images.githubusercontent.com/10608964/77893798-5dfe1f80-72af-11ea-8514-020590f42579.png)
```json
{
    "traceId": "61559458b511fabc",
    "id": "2a74a0d0317cd641",
    "kind": "PRODUCER",
    "name": "send message",
    "timestamp": 1585558223243729,
    "duration": 505172,
    "localEndpoint": {
        "serviceName": "sample-producer-app",
        "ipv4": "10.152.25.139"
    }
},
{
    "traceId": "61559458b511fabc",
    "parentId": "2a74a0d0317cd641",
    "id": "a40567c56200025a",
    "kind": "CONSUMER",
    "name": "process message",
    "timestamp": 1585558224756748,
    "duration": 2858012,
    "localEndpoint": {
        "serviceName": "sample-consumer-app",
        "ipv4": "10.152.25.139"
    },
    "tags": {
        "sample-tag": "xxxxxxx"
    }
}
```

Please review and merge. @adriancole @jcarres-mdsol 