### PR TITLE
Fixing race condition

### DIFF
--- a/Src/zipkin4net/Src/BaseStandardTrace.cs
+++ b/Src/zipkin4net/Src/BaseStandardTrace.cs
@@ -31,7 +31,7 @@ namespace zipkin4net
         {
             try
             {
-                return await task;
+                return await task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -50,7 +50,7 @@ namespace zipkin4net
         {
             try
             {
-                await task;
+                await task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/Src/zipkin4net/Src/Transport/Http/TracingHandler.cs
+++ b/Src/zipkin4net/Src/Transport/Http/TracingHandler.cs
@@ -74,7 +74,7 @@ namespace zipkin4net.Transport.Http
                     _injector.Inject(clientTrace.Trace.CurrentSpan, request.Headers);
                 }
 
-                var result = await clientTrace.TracedActionAsync(base.SendAsync(request, cancellationToken));
+                var result = await clientTrace.TracedActionAsync(base.SendAsync(request, cancellationToken)).ConfigureAwait(false);
 
                 if (clientTrace.Trace != null)
                 {


### PR DESCRIPTION
Within DotNet Framework API project, awaited task will invoke but never return control to the calling application. This is dependent on the calling application structure prior to calling.

Upon researching this issue, .Net Standard projects pulled into Framework still require ConfigureAwait(false) through the entire stack.