### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/Src/zipkin4net.middleware.aspnetcore/Src/zipkin4net.middleware.aspnetcore.csproj
+++ b/Src/zipkin4net.middleware.aspnetcore/Src/zipkin4net.middleware.aspnetcore.csproj
@@ -12,7 +12,15 @@
     <PackageReleaseNotes>Asp.net core middleware for zipkin4net</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/openzipkin/zipkin4net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/openzipkin/zipkin4net/blob/master/LICENSE</PackageLicenseUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.1" />

--- a/Src/zipkin4net.middleware.owin/Src/zipkin4net.middleware.owin.csproj
+++ b/Src/zipkin4net.middleware.owin/Src/zipkin4net.middleware.owin.csproj
@@ -22,7 +22,15 @@
     <PackageTags>Zipkin;Tracer;Tracing;Criteo;zipkin4net;owin</PackageTags>
     <PackageProjectUrl>https://github.com/openzipkin/zipkin4net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/openzipkin/zipkin4net/blob/master/LICENSE</PackageLicenseUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />

--- a/Src/zipkin4net/Benchmark/zipkin4net.Benchmark.csproj
+++ b/Src/zipkin4net/Benchmark/zipkin4net.Benchmark.csproj
@@ -12,7 +12,15 @@
     <PackageReleaseNotes>Benchmark for zipkin4net</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/criteo/zipkin4net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/criteo/zipkin4net/blob/master/LICENSE</PackageLicenseUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="../Src/zipkin4net.csproj" />

--- a/Src/zipkin4net/Src/zipkin4net.csproj
+++ b/Src/zipkin4net/Src/zipkin4net.csproj
@@ -21,7 +21,15 @@
     <PackageTags>Zipkin;Tracer;Tracing;Criteo;zipkin4net</PackageTags>
     <PackageProjectUrl>https://github.com/openzipkin/zipkin4net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/openzipkin/zipkin4net/blob/master/LICENSE</PackageLicenseUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.4' OR '$(TargetFramework)' == 'netstandard1.6'">
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
