### PR TITLE
adjust: use same id for root span id and trace id

### DIFF
--- a/Src/zipkin4net/Src/Trace.cs
+++ b/Src/zipkin4net/Src/Trace.cs
@@ -51,10 +51,9 @@ namespace zipkin4net
         }
         private Trace()
         {
-            var traceId = RandomUtils.NextLong();
-            var traceIdHigh = TraceManager.Trace128Bits ? RandomUtils.NextLong() : 0;
             var spanId = RandomUtils.NextLong();
-
+            var traceId = spanId;
+            var traceIdHigh = TraceManager.Trace128Bits ? RandomUtils.NextLong() : 0;
             var isSampled = TraceManager.Sampler.Sample(traceId);
 
             CurrentSpan = new SpanState(traceIdHigh: traceIdHigh, traceId: traceId, parentSpanId: null, spanId: spanId, isSampled: isSampled, isDebug: false);


### PR DESCRIPTION
# Uniform specification
In other languages, whether it is `Java`, `Go` or `PHP`, when we use 64bit ID, the span id and trace id of the root node are equal.
Reference: 
1. [Java Root ID](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/Tracer.java#L271-L276)
2. [Go Root ID](https://github.com/openzipkin/zipkin-go/blob/master/tracer.go#L125-L126)
3. [PHP Root ID](https://github.com/openzipkin/zipkin-php/blob/master/src/Zipkin/Propagation/TraceContext.php#L97-L99)

solve: #249 