### PR TITLE
Adding extractors and injectors

### DIFF
--- a/Src/zipkin4net/Src/Transport/ZipkinHttpHelper.cs
+++ b/Src/zipkin4net/Src/Transport/ZipkinHttpHelper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace zipkin4net.Transport
+{
+	public static class ZipkinHttpHelper
+	{
+        public static void InjectionHelper(HttpClient carrier, string key, string value)
+        {
+            carrier.DefaultRequestHeaders.Add(key, value);
+        }
+
+        public static string ExtractorHelper(HttpRequestHeaders carrier, string key)
+        {
+            IEnumerable<string> headerValues;
+            string header = string.Empty;
+            if (carrier.TryGetValues(key, out headerValues))
+            {
+                header = headerValues.FirstOrDefault();
+            }
+
+            return header;
+        }
+    }
+}
+

--- a/Src/zipkin4net/Src/Transport/ZipkinHttpHelper.cs
+++ b/Src/zipkin4net/Src/Transport/ZipkinHttpHelper.cs
@@ -8,7 +8,7 @@ namespace zipkin4net.Transport
 {
 	public static class ZipkinHttpHelper
 	{
-        public static void InjectionHelper(HttpClient carrier, string key, string value)
+        public static void InjectorHelper(HttpClient carrier, string key, string value)
         {
             carrier.DefaultRequestHeaders.Add(key, value);
         }

--- a/Src/zipkin4net/Tests/Transport/T_ZipkinHttpHelper.cs
+++ b/Src/zipkin4net/Tests/Transport/T_ZipkinHttpHelper.cs
@@ -32,6 +32,8 @@ namespace zipkin4net.UTests.Transport
             Assert.AreEqual(ZipkinHttpHelper.ExtractorHelper(carrier, key), string.Empty);
         }
 
+		// No test needed for Injector
+
 	}
 }
 

--- a/Src/zipkin4net/Tests/Transport/T_ZipkinHttpHelper.cs
+++ b/Src/zipkin4net/Tests/Transport/T_ZipkinHttpHelper.cs
@@ -1,0 +1,37 @@
+﻿using zipkin4net.Transport;
+using NUnit.Framework;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+
+namespace zipkin4net.UTests.Transport
+{
+	[TestFixture]
+	internal class T_ZipkinHttpHelper
+	{
+		[Test]
+		[TestCase("X-B3-TraceId", "Test_TraceID_123")]
+        [TestCase("", "Test_TraceID_123")]
+        [TestCase("", "")]
+        public void ExtractorCorrectlyExtractsExistingHeader(string key, string value)
+		{
+			var carrier = new HttpRequestMessage().Headers;
+			carrier.Add(key, value);
+
+			Assert.AreEqual(ZipkinHttpHelper.ExtractorHelper(carrier, key), value);
+		}
+
+		[Test]
+        [TestCase("X-B3-TraceId")]
+        [TestCase("")]
+        public void ExtractorCorrectlyExtractsNonExistentHeader(string key)
+		{
+            var carrier = new HttpRequestMessage().Headers;
+            Assert.AreEqual(ZipkinHttpHelper.ExtractorHelper(carrier, key), string.Empty);
+        }
+
+	}
+}
+


### PR DESCRIPTION
Adding implementations of http header injector and extractor. When instantiating an `IExtractor` or `IInjector` objects and calling `Inject()` or `Extract()`, you need to pass in a function that does the actual injection/extraction. Use the provided methods to do so