### PR TITLE
Update System.Net.Http to version 4.3.4 due to multiple CVEs

### DIFF
--- a/Examples/aspnetcore/backend/backend.csproj
+++ b/Examples/aspnetcore/backend/backend.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
   </ItemGroup>
 

--- a/Examples/aspnetcore/common/common.csproj
+++ b/Examples/aspnetcore/common/common.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Examples/aspnetcore/frontend/frontend.csproj
+++ b/Examples/aspnetcore/frontend/frontend.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
   </ItemGroup>
 

--- a/Examples/owin/backend/example.owin.backend.csproj
+++ b/Examples/owin/backend/example.owin.backend.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="3.1.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/owin/common/example.owin.common.csproj
+++ b/Examples/owin/common/example.owin.common.csproj
@@ -23,7 +23,7 @@
    <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
    <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="3.1.0" />
    <PackageReference Include="Microsoft.Owin.Hosting" Version="3.1.0" />
-   <PackageReference Include="System.Net.Http" Version="4.3.0" />
+   <PackageReference Include="System.Net.Http" Version="4.3.4" />
    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Examples/owin/frontend/example.owin.frontend.csproj
+++ b/Examples/owin/frontend/example.owin.frontend.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="3.1.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/zipkin4net.middleware.aspnetcore/Src/zipkin4net.middleware.aspnetcore.csproj
+++ b/Src/zipkin4net.middleware.aspnetcore/Src/zipkin4net.middleware.aspnetcore.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/zipkin4net.middleware.owin/Src/zipkin4net.middleware.owin.csproj
+++ b/Src/zipkin4net.middleware.owin/Src/zipkin4net.middleware.owin.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/zipkin4net/Src/zipkin4net.csproj
+++ b/Src/zipkin4net/Src/zipkin4net.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Apache.Thrift" Version="1.0.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This PR is to update System.Net.Requests to version 4.3.4 due to some CVE's on the version installed.

solves: #252 